### PR TITLE
fix: use resolveTheme instead systemTheme

### DIFF
--- a/components/common/Layout/Layout.js
+++ b/components/common/Layout/Layout.js
@@ -22,7 +22,7 @@ export function Layout({ children }) {
 }
 
 const Header = () => {
-  const { theme, setTheme, systemTheme } = useTheme();
+  const { setTheme, resolvedTheme } = useTheme();
   const { pathname } = useRouter();
   const [mounted, setMounted] = useState(false);
 
@@ -36,7 +36,7 @@ const Header = () => {
   };
 
   const isRoot = pathname === "/";
-  const isDarkMode = theme === "dark" || systemTheme === "dark";
+  const isDarkMode = resolvedTheme === "dark";
 
   return (
     <header

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,7 +7,7 @@ import "typeface-merriweather";
 
 export default function MyApp({ Component, pageProps }) {
   return (
-    <ThemeProvider defaultTheme="system" attribute="class">
+    <ThemeProvider defaultTheme="system" enableSystem={true} attribute="class">
       <Component {...pageProps} />
     </ThemeProvider>
   );


### PR DESCRIPTION
from docs

resolvedTheme: If enableSystem is true and the active theme is "system", this returns whether the system preference resolved to "dark" or "light". Otherwise, identical to theme